### PR TITLE
Add support for `oneof` in proto3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - export PATH=$PATH:$HOME/soft/protobuf
 
 install:
+  - go get github.com/stretchr/testify
   - go get github.com/gogo/protobuf/protoc-gen-gogo
   - go get github.com/golang/protobuf/protoc-gen-go
 

--- a/Makefile
+++ b/Makefile
@@ -4,32 +4,29 @@
 export PATH := ${GOPATH}/bin:${PATH}
 
 install:
-	@echo "Installing govalidators to GOPATH"
+	@echo "--- Installing govalidators to GOPATH"
 	go install github.com/mwitkow/go-proto-validators/protoc-gen-govalidators
 
 regenerate_test_gogo:
 	@echo "Regenerating test .proto files with gogo imports"
 	(protoc  \
 	--proto_path=${GOPATH}/src \
-	--proto_path=${GOPATH}/src/github.com/gogo/protobuf/protobuf \
  	--proto_path=test \
 	--gogo_out=test/gogo \
 	--govalidators_out=gogoimport=true:test/gogo test/*.proto)
 
 regenerate_test_golang:
-	@echo "Regenerating test .proto files"
+	@echo "--- Regenerating test .proto files with golang imports"
 	(protoc  \
 	--proto_path=${GOPATH}/src \
-	--proto_path=${GOPATH}/src/github.com/google/protobuf/src \
  	--proto_path=test \
 	--go_out=test/golang \
 	--govalidators_out=test/golang test/*.proto)
 
 regenerate_example: install
-	@echo "Regenerating example directory"
+	@echo "--- Regenerating example directory"
 	(protoc  \
 	--proto_path=${GOPATH}/src \
-	--proto_path=${GOPATH}/src/github.com/google/protobuf/src \
 	--proto_path=. \
 	--go_out=. \
 	--govalidators_out=. examples/*.proto)
@@ -39,7 +36,7 @@ test: install regenerate_test_gogo regenerate_test_golang
 	go test -v ./...
 
 regenerate:
-	@echo "Regenerating validator.proto"
+	@echo "--- Regenerating validator.proto"
 	(protoc \
 	--proto_path=${GOPATH}/src \
 	--proto_path=${GOPATH}/src/github.com/gogo/protobuf/protobuf \

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -210,7 +210,8 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 		if fieldValidator == nil && !field.IsMessage() {
 			continue
 		}
-		fieldName := p.GetFieldName(message, field)
+		isOneOf := field.OneofIndex != nil
+		fieldName := p.GetOneOfFieldName(message, field)
 		variableName := "this." + fieldName
 		repeated := field.IsRepeated()
 		// Golang's proto3 has no concept of unset primitive fields
@@ -218,6 +219,14 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 		if p.fieldIsProto3Map(file, message, field) {
 			p.P(`// Validation of proto3 map<> fields is unsupported.`)
 			continue
+		}
+		if isOneOf {
+			p.In()
+			oneOfName := p.GetFieldName(message, field)
+			oneOfType := p.OneOfTypeName(message, field)
+			//if x, ok := m.GetType().(*OneOfMessage3_OneInt); ok {
+			p.P(`if oneOfNester, ok := this.Get` + oneOfName + `().(* ` + oneOfType + `); ok {`)
+			variableName = "oneOfNester." + p.GetOneOfFieldName(message, field)
 		}
 		if repeated {
 			p.P(`for _, item := range `, variableName, `{`)
@@ -261,6 +270,11 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 		}
 		if repeated {
 			// end the repeated loop
+			p.Out()
+			p.P(`}`)
+		}
+		if isOneOf {
+			// end the oneof if statement
 			p.Out()
 			p.P(`}`)
 		}

--- a/test/golang/validator_test.go
+++ b/test/golang/validator_test.go
@@ -4,8 +4,10 @@
 package validatortest
 
 import (
-	"testing"
 	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func buildProto3(someString string, someInt uint32, identifier string, someValue int64) *ValidatorMessage3 {
@@ -162,4 +164,57 @@ func TestMapAlwaysPassesUntilFixedProperly(t *testing.T) {
 	if err := example.Validate(); err != nil {
 		t.Fatalf("map validators should always pass")
 	}
+}
+
+func TestOneOf_NestedMessage(t *testing.T) {
+	example := &OneOfMessage3{
+		SomeInt: 30,
+		Type: &OneOfMessage3_OneMsg{
+			OneMsg: &ExternalMsg{
+				Identifier: "999", // bad
+				SomeValue:  99,    // good
+			},
+		},
+		Something: &OneOfMessage3_ThreeInt{
+			ThreeInt: 100, // > 20
+		},
+	}
+	err := example.Validate()
+	assert.Error(t, err, "nested message in oneof should fail validation on ExternalMsg")
+	assert.Contains(t, err.Error(), "OneMsg.Identifier", "error must err on the ExternalMsg.Identifier")
+}
+
+func TestOneOf_NestedInt(t *testing.T) {
+	example := &OneOfMessage3{
+		SomeInt: 30,
+		Type: &OneOfMessage3_OneMsg{
+			OneMsg: &ExternalMsg{
+				Identifier: "abba", // good
+				SomeValue:  99,     // good
+			},
+		},
+		Something: &OneOfMessage3_ThreeInt{
+			ThreeInt: 19, // > 20
+		},
+	}
+	err := example.Validate()
+	assert.Error(t, err, "nested message in oneof should fail validation on ThreeInt")
+	assert.Contains(t, err.Error(), "ThreeInt", "error must err on the ThreeInt.ThreeInt")
+}
+
+func TestOneOf_Passes(t *testing.T) {
+	example := &OneOfMessage3{
+		SomeInt: 30,
+		Type: &OneOfMessage3_OneMsg{
+			OneMsg: &ExternalMsg{
+				Identifier: "abba", // good
+				SomeValue:  99,     // good
+			},
+		},
+		Something: &OneOfMessage3_FourInt{
+			FourInt: 101, // > 101
+		},
+	}
+	err := example.Validate()
+	assert.NoError(t, err, "This message should pass all validation")
 }

--- a/test/validator_proto3.proto
+++ b/test/validator_proto3.proto
@@ -28,5 +28,6 @@ message ValidatorMessage3 {
 	repeated Embedded someEmbeddedRepNonNullable = 15 [(gogoproto.nullable) = false];
 
 	int32 CustomErrorInt = 16 [(validator.field) = {int_lt: 10, human_error: "My Custom Error"}];
-
 }
+
+

--- a/test/validator_proto3_oneof.proto
+++ b/test/validator_proto3_oneof.proto
@@ -1,0 +1,28 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+syntax = "proto3";
+package validatortest;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/mwitkow/go-proto-validators/validator.proto";
+
+message ExternalMsg {
+  string Identifier = 1 [(validator.field) = {regex: "^[a-z]{2,5}$"}];
+  int64 SomeValue = 2 [(validator.field) = {int_gt: 0, int_lt: 100}];
+}
+
+message OneOfMessage3 {
+  uint32 SomeInt = 1  [(validator.field) = {int_gt: 10}];
+
+  oneof type {
+    ExternalMsg one_msg = 2;
+    uint32 one_int = 3 [(validator.field) = {int_gt: 20}];
+    uint32 two_int = 4 [(validator.field) = {int_gt: 100}];
+  }
+
+  oneof something {
+    uint32 three_int = 5 [(validator.field) = {int_gt: 20}];
+    uint32 four_int = 6 [(validator.field) = {int_gt: 100}];
+  }
+}


### PR DESCRIPTION
`oneof` messages no longer fail to comile.
`oneof` messages now call appropriate validators for the field that is actually present, and doesn't for the rest.
supports both `golang/protobuf` and `gogo/protobuf`.

Fixes https://github.com/mwitkow/go-proto-validators/issues/10