### PR TITLE
Change annotation to field options in readme to align with official protobuf documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis Build](https://travis-ci.org/mwitkow/go-proto-validators.svg)](https://travis-ci.org/mwitkow/go-proto-validators)
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-A `protoc` plugin that generates `Validate() error` functions on Go proto `struct`s based on annotations inside `.proto` 
+A `protoc` plugin that generates `Validate() error` functions on Go proto `struct`s based on field options inside `.proto` 
 files. The validation functions are code-generated and thus don't suffer on performance from tag-based reflection on
 deeply-nested messages.
 
@@ -95,7 +95,7 @@ protoc  \
 	*.proto
 ```
 
-That's fine, until you encounter `.proto` includes. Because `go-proto-validators` uses annotations inside the `.proto` 
+That's fine, until you encounter `.proto` includes. Because `go-proto-validators` uses field options inside the `.proto` 
 files themselves, it's `.proto` definition (and the Google `descriptor.proto` itself) need to on the `protoc` include
 path. Hence the above becomes:
 


### PR DESCRIPTION
In the official documentation, the annotations are called field options: 
- https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#normal_field
- https://developers.google.com/protocol-buffers/docs/proto3#options

Changing `annotation` to `field options` makes the terms being used consistent.