### PR TITLE
Use backticks to escape regular expressions

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -148,7 +148,7 @@ func (p *plugin) generateRegexVars(file *generator.FileDescriptor, message *gene
 		validator := getFieldValidatorIfAny(field)
 		if validator != nil && validator.Regex != nil {
 			fieldName := p.GetFieldName(message, field)
-			p.P(`var `, p.regexName(ccTypeName, fieldName), ` = `, p.regexPkg.Use(), `.MustCompile(`, strconv.Quote(*validator.Regex), `)`)
+			p.P(`var `, p.regexName(ccTypeName, fieldName), ` = `, p.regexPkg.Use(), `.MustCompile(`, "`", *validator.Regex, "`", `)`)
 		}
 	}
 }
@@ -204,7 +204,7 @@ func (p *plugin) generateProto2Message(file *generator.FileDescriptor, message *
 			p.generateIntValidator(variableName, ccTypeName, fieldName, fieldValidator)
 		} else if p.isSupportedFloat(field) {
 			p.generateFloatValidator(variableName, ccTypeName, fieldName, fieldValidator)
-		} else if (field.IsBytes()) {
+		} else if field.IsBytes() {
 			p.generateLengthValidator(variableName, ccTypeName, fieldName, fieldValidator)
 		} else if field.IsMessage() {
 			if repeated && nullable {
@@ -282,7 +282,7 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 			p.generateIntValidator(variableName, ccTypeName, fieldName, fieldValidator)
 		} else if p.isSupportedFloat(field) {
 			p.generateFloatValidator(variableName, ccTypeName, fieldName, fieldValidator)
-		} else if (field.IsBytes()) {
+		} else if field.IsBytes() {
 			p.generateLengthValidator(variableName, ccTypeName, fieldName, fieldValidator)
 		} else if field.IsMessage() {
 			if p.validatorWithMessageExists(fieldValidator) {

--- a/test/gogo/validator_test.go
+++ b/test/gogo/validator_test.go
@@ -6,22 +6,26 @@ package validatortest
 import (
 	"strings"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
+
 var (
-	stableBytes = make([]byte,12)
+	stableBytes = make([]byte, 12)
 )
+
 func buildProto3(someString string, someInt uint32, identifier string, someValue int64, someDoubleStrict float64,
-someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32,someStringLength string, someBytes []byte) *ValidatorMessage3 {
+	someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32, someStringLength string, someBytes []byte) *ValidatorMessage3 {
 	goodEmbeddedProto3 := &ValidatorMessage3_Embedded{
 		Identifier: identifier,
 		SomeValue:  someValue,
 	}
 
 	goodProto3 := &ValidatorMessage3{
-		SomeString:         someString,
-		SomeStringRep:      []string{someString, "xyz34"},
-		SomeStringNoQuotes: someString,
+		SomeString:          someString,
+		SomeStringRep:       []string{someString, "xyz34"},
+		SomeStringNoQuotes:  someString,
+		SomeStringUnescaped: someString,
 
 		SomeInt:           someInt,
 		SomeIntRep:        []uint32{someInt, 12, 13, 14, 15, 16},
@@ -48,13 +52,13 @@ someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString s
 		SomeFloatRepNonNull:  []float32{someFloat, 0.5, 0.55, 0.6},
 
 		SomeNonEmptyString: nonEmptyString,
-		SomeStringEqReq: someStringLength,
-		SomeStringLtReq: someStringLength,
-		SomeStringGtReq: someStringLength,
+		SomeStringEqReq:    someStringLength,
+		SomeStringLtReq:    someStringLength,
+		SomeStringGtReq:    someStringLength,
 
-		SomeBytesLtReq:someBytes,
-		SomeBytesGtReq:someBytes,
-		SomeBytesEqReq:someBytes,
+		SomeBytesLtReq:   someBytes,
+		SomeBytesGtReq:   someBytes,
+		SomeBytesEqReq:   someBytes,
 		RepeatedBaseType: []int32{},
 	}
 
@@ -64,7 +68,7 @@ someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString s
 }
 
 func buildProto2(someString string, someInt uint32, identifier string, someValue int64, someDoubleStrict float64,
-someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32,someStringLength string, someBytes []byte) *ValidatorMessage {
+	someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32, someStringLength string, someBytes []byte) *ValidatorMessage {
 	goodEmbeddedProto2 := &ValidatorMessage_Embedded{
 		Identifier: &identifier,
 		SomeValue:  &someValue,
@@ -76,6 +80,8 @@ someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString s
 
 		StringOpt:        nil,
 		StringOptNonNull: someString,
+
+		StringUnescaped: &someString,
 
 		IntReq:        &someInt,
 		IntReqNonNull: someInt,
@@ -106,13 +112,13 @@ someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString s
 		SomeFloatRepNonNull:  []float32{someFloat, 0.5, 0.55, 0.6},
 
 		SomeNonEmptyString: &nonEmptyString,
-		SomeStringEqReq: &someStringLength,
-		SomeStringLtReq: &someStringLength,
-		SomeStringGtReq: &someStringLength,
+		SomeStringEqReq:    &someStringLength,
+		SomeStringLtReq:    &someStringLength,
+		SomeStringGtReq:    &someStringLength,
 
-		SomeBytesLtReq:someBytes,
-		SomeBytesGtReq:someBytes,
-		SomeBytesEqReq:someBytes,
+		SomeBytesLtReq:   someBytes,
+		SomeBytesGtReq:   someBytes,
+		SomeBytesEqReq:   someBytes,
 		RepeatedBaseType: []int32{},
 	}
 
@@ -123,7 +129,7 @@ someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString s
 
 func TestGoodProto3(t *testing.T) {
 	var err error
-	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	err = goodProto3.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -132,7 +138,7 @@ func TestGoodProto3(t *testing.T) {
 
 func TestGoodProto2(t *testing.T) {
 	var err error
-	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	err = goodProto2.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -140,254 +146,254 @@ func TestGoodProto2(t *testing.T) {
 }
 
 func TestStringRegex(t *testing.T) {
-	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong2Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong2Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntLowerBounds(t *testing.T) {
-	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan10Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan10Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntUpperBounds(t *testing.T) {
-	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan100Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan100Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestDoubleStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan035EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan035EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestDoubleStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan065EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan065EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestFloatStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := greaterThan035EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := greaterThan035EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := lowerThan065EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := lowerThan065EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestStringNonEmpty(t *testing.T) {
-	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4,"1234567890",stableBytes)
+	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes)
 	if emptyStringProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4,"1234567890",stableBytes)
+	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes)
 	if emptyStringProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := nonEmptyStringProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := nonEmptyStringProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestRepeatedEltsCount(t *testing.T) {
-	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1,"1234567890",stableBytes)
+	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes)
 	if notEnoughEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1,"1234567890",stableBytes)
+	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes)
 	if notEnoughEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14,"1234567890",stableBytes)
+	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes)
 	if tooManyEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14,"1234567890",stableBytes)
+	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes)
 	if tooManyEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := validEltsCountProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := validEltsCountProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestMsgExist(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	someProto3.SomeEmbedded = nil
 	if err := someProto3.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on missing SomeEmbedded, not annotated")
@@ -401,7 +407,7 @@ func TestMsgExist(t *testing.T) {
 }
 
 func TestNestedError3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	someProto3.SomeEmbeddedExists.SomeValue = 101 // should be less than 101
 	if err := someProto3.Validate(); err == nil {
 		t.Fatalf("expected fail due to nested SomeEmbeddedExists.SomeValue being wrong")
@@ -411,7 +417,7 @@ func TestNestedError3(t *testing.T) {
 }
 
 func TestCustomError_Proto3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	someProto3.CustomErrorInt = 30
 	expectedErr := "invalid field CustomErrorInt: My Custom Error"
 	if err := someProto3.Validate(); err == nil {

--- a/test/golang/validator_test.go
+++ b/test/golang/validator_test.go
@@ -6,24 +6,27 @@ package validatortest
 import (
 	"strings"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	stableBytes = make([]byte,12)
+	stableBytes = make([]byte, 12)
 )
+
 func buildProto3(someString string, someInt uint32, identifier string, someValue int64, someDoubleStrict float64,
-someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32,
-someStringLength string, someBytes []byte) *ValidatorMessage3 {
+	someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32,
+	someStringLength string, someBytes []byte) *ValidatorMessage3 {
 	goodEmbeddedProto3 := &ValidatorMessage3_Embedded{
 		Identifier: identifier,
 		SomeValue:  someValue,
 	}
 
 	goodProto3 := &ValidatorMessage3{
-		SomeString:         someString,
-		SomeStringRep:      []string{someString, "xyz34"},
-		SomeStringNoQuotes: someString,
+		SomeString:          someString,
+		SomeStringRep:       []string{someString, "xyz34"},
+		SomeStringNoQuotes:  someString,
+		SomeStringUnescaped: someString,
 
 		SomeInt:           someInt,
 		SomeIntRep:        []uint32{someInt, 12, 13, 14, 15, 16},
@@ -50,14 +53,13 @@ someStringLength string, someBytes []byte) *ValidatorMessage3 {
 		SomeFloatRepNonNull:  []float32{someFloat, 0.5, 0.55, 0.6},
 
 		SomeNonEmptyString: nonEmptyString,
-		SomeStringEqReq: someStringLength,
-		SomeStringLtReq: someStringLength,
-		SomeStringGtReq: someStringLength,
+		SomeStringEqReq:    someStringLength,
+		SomeStringLtReq:    someStringLength,
+		SomeStringGtReq:    someStringLength,
 
-		SomeBytesLtReq:someBytes,
-		SomeBytesGtReq:someBytes,
-		SomeBytesEqReq:someBytes,
-		
+		SomeBytesLtReq: someBytes,
+		SomeBytesGtReq: someBytes,
+		SomeBytesEqReq: someBytes,
 
 		RepeatedBaseType: []int32{},
 	}
@@ -67,7 +69,7 @@ someStringLength string, someBytes []byte) *ValidatorMessage3 {
 	return goodProto3
 }
 
-func buildProto2(someString string, someInt uint32, identifier string, someValue int64, someDoubleStrict float64, someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32, someStringLength string,someBytes []byte) *ValidatorMessage {
+func buildProto2(someString string, someInt uint32, identifier string, someValue int64, someDoubleStrict float64, someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32, someStringLength string, someBytes []byte) *ValidatorMessage {
 	goodEmbeddedProto2 := &ValidatorMessage_Embedded{
 		Identifier: &identifier,
 		SomeValue:  &someValue,
@@ -79,6 +81,8 @@ func buildProto2(someString string, someInt uint32, identifier string, someValue
 
 		StringOpt:        nil,
 		StringOptNonNull: &someString,
+
+		StringUnescaped: &someString,
 
 		IntReq:        &someInt,
 		IntReqNonNull: &someInt,
@@ -109,13 +113,13 @@ func buildProto2(someString string, someInt uint32, identifier string, someValue
 		SomeFloatRepNonNull:  []float32{someFloat, 0.5, 0.55, 0.6},
 
 		SomeNonEmptyString: &nonEmptyString,
-		SomeStringEqReq: &someStringLength,
-		SomeStringLtReq: &someStringLength,
-		SomeStringGtReq: &someStringLength,
-		SomeBytesLtReq:someBytes,
-		SomeBytesGtReq:someBytes,
-		SomeBytesEqReq:someBytes,
-		RepeatedBaseType: []int32{},
+		SomeStringEqReq:    &someStringLength,
+		SomeStringLtReq:    &someStringLength,
+		SomeStringGtReq:    &someStringLength,
+		SomeBytesLtReq:     someBytes,
+		SomeBytesGtReq:     someBytes,
+		SomeBytesEqReq:     someBytes,
+		RepeatedBaseType:   []int32{},
 	}
 
 	goodProto2.Repeated = make([]int32, repeatedCount, repeatedCount)
@@ -125,7 +129,7 @@ func buildProto2(someString string, someInt uint32, identifier string, someValue
 
 func TestGoodProto3(t *testing.T) {
 	var err error
-	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	err = goodProto3.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -134,7 +138,7 @@ func TestGoodProto3(t *testing.T) {
 
 func TestGoodProto2(t *testing.T) {
 	var err error
-	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	err = goodProto2.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -142,254 +146,254 @@ func TestGoodProto2(t *testing.T) {
 }
 
 func TestStringRegex(t *testing.T) {
-	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong2Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if tooLong2Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntLowerBounds(t *testing.T) {
-	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan10Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan10Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntUpperBounds(t *testing.T) {
-	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan100Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan100Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestDoubleStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan035EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan035EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestDoubleStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan065EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan065EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestFloatStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := greaterThan035EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := greaterThan035EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := lowerThan065EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := lowerThan065EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4,"1234567890",stableBytes)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4,"1234567890",stableBytes)
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4,"1234567890",stableBytes)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestStringNonEmpty(t *testing.T) {
-	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4,"1234567890",stableBytes)
+	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes)
 	if emptyStringProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4,"1234567890",stableBytes)
+	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes)
 	if emptyStringProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := nonEmptyStringProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := nonEmptyStringProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestRepeatedEltsCount(t *testing.T) {
-	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1,"1234567890",stableBytes)
+	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes)
 	if notEnoughEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1,"1234567890",stableBytes)
+	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes)
 	if notEnoughEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14,"1234567890",stableBytes)
+	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes)
 	if tooManyEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14,"1234567890",stableBytes)
+	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes)
 	if tooManyEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := validEltsCountProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := validEltsCountProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestMsgExist(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	someProto3.SomeEmbedded = nil
 	if err := someProto3.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on missing SomeEmbedded, not annotated")
@@ -403,31 +407,31 @@ func TestMsgExist(t *testing.T) {
 }
 
 func TestStringLengthValidator(t *testing.T) {
-	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"abc456",stableBytes)
+	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "abc456", stableBytes)
 	if err := StringLengthErrorProto3.Validate(); err == nil {
 		t.Fatalf("validate shouldn't fail on error length")
 	}
 
-	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := StringLengthSuccess.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on equal length")
 	}
 }
 
 func TestBytesLengthValidator(t *testing.T) {
-	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"abc456",[]byte("anc"))
+	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "abc456", []byte("anc"))
 	if err := StringLengthErrorProto3.Validate(); err == nil {
 		t.Fatalf("validate shouldn't fail on error length")
 	}
 
-	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	if err := StringLengthSuccess.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on equal length")
 	}
 }
 
 func TestNestedError3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	someProto3.SomeEmbeddedExists.SomeValue = 101 // should be less than 101
 	if err := someProto3.Validate(); err == nil {
 		t.Fatalf("expected fail due to nested SomeEmbeddedNonNullable.SomeValue being wrong")
@@ -437,7 +441,7 @@ func TestNestedError3(t *testing.T) {
 }
 
 func TestCustomError_Proto3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4,"1234567890",stableBytes)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes)
 	someProto3.CustomErrorInt = 30
 	expectedErr := "invalid field CustomErrorInt: My Custom Error"
 	if err := someProto3.Validate(); err == nil {
@@ -460,7 +464,7 @@ func TestOneOf_NestedMessage(t *testing.T) {
 		Type: &OneOfMessage3_OneMsg{
 			OneMsg: &ExternalMsg{
 				Identifier: "999", // bad
-				SomeValue:  99, // good
+				SomeValue:  99,    // good
 			},
 		},
 		Something: &OneOfMessage3_ThreeInt{
@@ -478,7 +482,7 @@ func TestOneOf_NestedInt(t *testing.T) {
 		Type: &OneOfMessage3_OneMsg{
 			OneMsg: &ExternalMsg{
 				Identifier: "abba", // good
-				SomeValue:  99, // good
+				SomeValue:  99,     // good
 			},
 		},
 		Something: &OneOfMessage3_ThreeInt{
@@ -496,7 +500,7 @@ func TestOneOf_Passes(t *testing.T) {
 		Type: &OneOfMessage3_OneMsg{
 			OneMsg: &ExternalMsg{
 				Identifier: "abba", // good
-				SomeValue:  99, // good
+				SomeValue:  99,     // good
 			},
 		},
 		Something: &OneOfMessage3_FourInt{

--- a/test/validator_proto2.proto
+++ b/test/validator_proto2.proto
@@ -19,6 +19,7 @@ message ValidatorMessage {
 	required string StringReqNonNull = 2 [(validator.field) = {regex: "^.{2,5}$"}, (gogoproto.nullable) = false];
 	optional string StringOpt = 3 [(validator.field) = {regex: "^.{2,5}$"}];
 	optional string StringOptNonNull = 4 [(validator.field) = {regex: "^.{2,5}$"}, (gogoproto.nullable) = false];
+	required string StringUnescaped = 5 [(validator.field) = {regex: "[\\p{L}\\p{N}]({\\p{L}\\p{N}_- ]{0,28}[\\p{L}\\p{N}])?."}];
 
 	// Strict integer inequality constraint tests.
 	required uint32 IntReq = 6 [(validator.field) = {int_gt: 10}];

--- a/test/validator_proto3.proto
+++ b/test/validator_proto3.proto
@@ -18,6 +18,7 @@ message ValidatorMessage3 {
 	string SomeString = 1 [(validator.field) = {regex: "^.{2,5}$"}];
 	repeated string SomeStringRep = 2 [(validator.field) = {regex: "^.{2,5}$"}];
 	string SomeStringNoQuotes = 3 [(validator.field) = {regex: "^[^\"]{2,5}$"}];
+	string SomeStringUnescaped = 4 [(validator.field) = {regex: "[\\p{L}\\p{N}]({\\p{L}\\p{N}_- ]{0,28}[\\p{L}\\p{N}])?."}];
 
 	// Strict integer inequality constraint tests.
 	uint32 SomeInt = 6 [(validator.field) = {int_gt: 10}];


### PR DESCRIPTION
I modified the code to use backticks and added an appropriate regex in the tests which failes when using upstream/master as described in #32. This PR fixes #32.