### PR TITLE
Update protoc to 3.7 and fix a panic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 
 before_install:
   - ./install_protoc.sh
-  - export PATH=$PATH:$HOME/soft/protobuf
+  - export PATH=$PATH:$HOME/soft/protobuf/bin
 
 install:
   - go get github.com/stretchr/testify

--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -4,7 +4,7 @@
 #
 # This script installs protobuf compiler `protoc` into PATH.
 
-version=${PROTOBUF_VERSION:-"3.0.0-beta-2"}
+version=${PROTOBUF_VERSION:-"3.7.0"}
 dst_dir="${HOME}/soft/protobuf"
 
 # Fail on issues.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -597,10 +597,18 @@ func (p *plugin) validatorWithNonRepeatedConstraint(fv *validator.FieldValidator
 	// Need to use reflection in order to be future-proof for new types of constraints.
 	v := reflect.ValueOf(*fv)
 	for i := 0; i < v.NumField(); i++ {
-		if v.Type().Field(i).Name != "RepeatedCountMin" && v.Type().Field(i).Name != "RepeatedCountMax" && v.Field(i).Pointer() != 0 {
-			return true
+		fieldName := v.Type().Field(i).Name
+		if fieldName != "RepeatedCountMin" && fieldName != "RepeatedCountMax" && !strings.HasPrefix(fieldName, "XXX_") {
+			k := v.Field(i).Kind()
+
+			if k == reflect.Map || k == reflect.Ptr || k == reflect.Slice || k == reflect.UnsafePointer {
+				if v.Field(i).Pointer() != 0 {
+					return true
+				}
+			}
 		}
 	}
+
 	return false
 }
 


### PR DESCRIPTION
```
commit c2d1e99caab85a1ff8d53d79d2f844d3aeac129c (HEAD -> update-protoc-upstream-pr, origin/update-protoc-upstream-pr)
Author: Fabian Holler <fabian.holler@simplesurance.de>
Date:   Fri Feb 8 16:24:07 2019 +0100

    fix panic in validatorWithNonRepeatedConstraint
    
    Since the
    When the validator.pb.go is compiled with a recent protoc version, new
    internal XXX_NoUnkeyedLiteral files were added to the protobuf message
    structs.
    
    When validating the repeated rules, v.Field(i).Pointer() was called on
    the XXX_NoUnkeyedLiteral which is a struct. This caused a panic.
    
    Fix it by:
    1.) Ignore all fields called XXX_ in validatorWithNonRepeatedConstraint(), those are internal protobuf fields.
    2.) Ensure that Pointer() is only called if the field is a type that
        supports the Pointer() call. This is an additional safe-guard which
        is not required for the current generated pb message. 1.) already
        fixes the issue.
    
    This fixes the following panic:
      goroutine 1 [running]:
      reflect.Value.Pointer(0x67d380, 0xc00024c300, 0x99, 0x10)
            /usr/lib/go/src/reflect/value.go:1328 +0x188
      github.com/simplesurance/go-proto-validators/plugin.(*plugin).validatorWithNonRepeatedConstraint(0xc000099200, 0xc000229180, 0xd)
            /home/fho/git/go-proto-validators/plugin/plugin.go:583 +0x309
      github.com/simplesurance/go-proto-validators/plugin.(*plugin).generateProto2Message(0xc000099200, 0xc0000a4bb0, 0xc0001df360)
            /home/fho/git/go-proto-validators/plugin/plugin.go:178 +0x156b
      github.com/simplesurance/go-proto-validators/plugin.(*plugin).Generate(0xc000099200, 0xc0000a4bb0)
            /home/fho/git/go-proto-validators/plugin/plugin.go:106 +0x2db
      github.com/gogo/protobuf/protoc-gen-gogo/generator.(*Generator).generatePlugin(0xc0000de780, 0xc0000a4bb0, 0x70f420, 0xc000099200)
            /home/fho/go/pkg/mod/github.com/gogo/protobuf@v1.2.0/protoc-gen-gogo/generator/helper.go:361 +0xf3
      github.com/gogo/protobuf/protoc-gen-gogo/generator.(*Generator).GeneratePlugin(0xc0000de780, 0x70f420, 0xc000099200)
            /home/fho/go/pkg/mod/github.com/gogo/protobuf@v1.2.0/protoc-gen-gogo/generator/helper.go:338 +0x27e
      main.main()
            /home/fho/git/go-proto-validators/protoc-gen-govalidators/main.go:53 +0x329

commit 8578b6908435f9fa87fcd755e92b352232ba5d14
Author: Fabian Holler <fabian.holler@simplesurance.de>
Date:   Tue Mar 12 16:29:48 2019 +0100

    update to protoc 3.7.0
    
    update the protoc version to 3.7.0 in install_protoc.sh

```