### PR TITLE
ci: run tests against recent go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 sudo: false
 
 go:
-  - 1.5
-  - 1.6
+  - 1.11
+  - 1.12
 
 before_install:
   - ./install_protoc.sh


### PR DESCRIPTION
The tests in travis CI were run against go 1.5 and 1.6.
Change it to the recent latest 3 Go versions (1.10, 1.11, 1.12).