### PR TITLE
Validation for nested defined enum types

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -401,9 +401,9 @@ func (p *plugin) generateEnumValidator(
 	fv *validator.FieldValidator) {
 	if fv.GetIsInEnum() {
 		enum := p.ObjectNamed(field.GetTypeName()).(*generator.EnumDescriptor)
-		p.P(`if _, ok := `, enum.GetName(), "_name[int32(", variableName, ")]; !ok {")
+		p.P(`if _, ok := `, strings.Join(enum.TypeName(), "_"), "_name[int32(", variableName, ")]; !ok {")
 		p.In()
-		p.generateErrorString(variableName, fieldName, fmt.Sprintf("be a valid %s field", enum.GetName()), fv)
+		p.generateErrorString(variableName, fieldName, fmt.Sprintf("be a valid %s field", strings.Join(enum.TypeName(), "_")), fv)
 		p.Out()
 		p.P(`}`)
 	}

--- a/test/gogo/validator_test.go
+++ b/test/gogo/validator_test.go
@@ -24,8 +24,9 @@ func buildProto3(someString string, someInt uint32, identifier string,
 	someValue int64, someDoubleStrict float64, someFloatStrict float32, someDouble float64,
 	someFloat float32, nonEmptyString string, repeatedCount uint32,
 	someStringLength string, someBytes []byte,
-	optionalUUIDAny, uuid4 string) *ValidatorMessage3 {
-	goodEmbeddedProto3 := &ValidatorMessage3_Embedded{
+	optionalUUIDAny, uuid4 string,
+	someEnum int32, someEmbeddedEnum int32) *ValidatorMessage3 {
+	goodEmbeddedProto3 := &ValidatorMessage3_EmbeddedMessage{
 		Identifier: identifier,
 		SomeValue:  someValue,
 	}
@@ -43,8 +44,8 @@ func buildProto3(someString string, someInt uint32, identifier string,
 		SomeEmbedded:               nil,
 		SomeEmbeddedNonNullable:    *goodEmbeddedProto3,
 		SomeEmbeddedExists:         goodEmbeddedProto3,
-		SomeEmbeddedRep:            []*ValidatorMessage3_Embedded{goodEmbeddedProto3},
-		SomeEmbeddedRepNonNullable: []ValidatorMessage3_Embedded{*goodEmbeddedProto3},
+		SomeEmbeddedRep:            []*ValidatorMessage3_EmbeddedMessage{goodEmbeddedProto3},
+		SomeEmbeddedRepNonNullable: []ValidatorMessage3_EmbeddedMessage{*goodEmbeddedProto3},
 
 		StrictSomeDouble:           someDoubleStrict,
 		StrictSomeDoubleRep:        []float64{someDoubleStrict, 0.5, 0.55, 0.6},
@@ -72,6 +73,9 @@ func buildProto3(someString string, someInt uint32, identifier string,
 
 		UUIDAny:       optionalUUIDAny,
 		UUID4NotEmpty: uuid4,
+
+		SomeEnum:         EnumProto3(someEnum),
+		SomeEmbeddedEnum: ValidatorMessage3_EmbeddedEnum(someEmbeddedEnum),
 	}
 
 	goodProto3.Repeated = make([]int32, repeatedCount)
@@ -83,8 +87,9 @@ func buildProto2(someString string, someInt uint32, identifier string,
 	someValue int64, someDoubleStrict float64, someFloatStrict float32, someDouble float64,
 	someFloat float32, nonEmptyString string, repeatedCount uint32,
 	someStringLength string, someBytes []byte,
-	optionalUUIDAny, uuid5 string) *ValidatorMessage {
-	goodEmbeddedProto2 := &ValidatorMessage_Embedded{
+	optionalUUIDAny, uuid5 string,
+	someEnum int32, someEmbeddedEnum int32) *ValidatorMessage {
+	goodEmbeddedProto2 := &ValidatorMessage_EmbeddedMessage{
 		Identifier: &identifier,
 		SomeValue:  &someValue,
 	}
@@ -105,8 +110,8 @@ func buildProto2(someString string, someInt uint32, identifier string,
 
 		EmbeddedReq:            goodEmbeddedProto2,
 		EmbeddedNonNull:        *goodEmbeddedProto2,
-		EmbeddedRep:            []*ValidatorMessage_Embedded{goodEmbeddedProto2},
-		EmbeddedRepNonNullable: []ValidatorMessage_Embedded{*goodEmbeddedProto2},
+		EmbeddedRep:            []*ValidatorMessage_EmbeddedMessage{goodEmbeddedProto2},
+		EmbeddedRepNonNullable: []ValidatorMessage_EmbeddedMessage{*goodEmbeddedProto2},
 
 		StrictSomeDoubleReq:        &someDoubleStrict,
 		StrictSomeDoubleReqNonNull: someDoubleStrict,
@@ -138,6 +143,9 @@ func buildProto2(someString string, someInt uint32, identifier string,
 
 		UUIDAny:       &optionalUUIDAny,
 		UUID4NotEmpty: &uuid5,
+
+		SomeEnum:         (*EnumProto2)(&someEnum),
+		SomeEmbeddedEnum: (*ValidatorMessage_EmbeddedEnum)(&someEmbeddedEnum),
 	}
 
 	goodProto2.Repeated = make([]int32, repeatedCount)
@@ -147,7 +155,7 @@ func buildProto2(someString string, someInt uint32, identifier string,
 
 func TestGoodProto3(t *testing.T) {
 	var err error
-	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 1, 1)
 	err = goodProto3.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -156,7 +164,7 @@ func TestGoodProto3(t *testing.T) {
 
 func TestGoodProto2(t *testing.T) {
 	var err error
-	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 1, 1)
 	err = goodProto2.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -164,254 +172,254 @@ func TestGoodProto2(t *testing.T) {
 }
 
 func TestStringRegex(t *testing.T) {
-	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooLong1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-	if tooLong2Proto3.Validate() == nil {
-		t.Fatalf("expected fail in validator, but it didn't happen")
-	}
-	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooLong1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
+	if tooLong2Proto3.Validate() == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooLong2Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntLowerBounds(t *testing.T) {
-	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan10Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan10Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntUpperBounds(t *testing.T) {
-	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan100Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan100Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestDoubleStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan035EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan035EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestDoubleStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan065EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan065EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestFloatStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := greaterThan035EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := greaterThan035EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := lowerThan065EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := lowerThan065EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestStringNonEmpty(t *testing.T) {
-	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4)
+	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if emptyStringProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4)
+	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if emptyStringProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := nonEmptyStringProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := nonEmptyStringProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestRepeatedEltsCount(t *testing.T) {
-	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4)
+	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if notEnoughEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4)
+	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if notEnoughEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4)
+	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooManyEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4)
+	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooManyEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := validEltsCountProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := validEltsCountProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestMsgExist(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	someProto3.SomeEmbedded = nil
 	if err := someProto3.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on missing SomeEmbedded, not annotated")
@@ -424,8 +432,27 @@ func TestMsgExist(t *testing.T) {
 	}
 }
 
+func TestValueIsInEnum(t *testing.T) {
+	outOfTopLevelEnumProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 2, 0)
+	if err := outOfTopLevelEnumProto3.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	outOfTopLevelEnumProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 2, 0)
+	if err := outOfTopLevelEnumProto2.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	outOfEmbeddedEnumProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 2)
+	if err := outOfEmbeddedEnumProto3.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	outOfEmbeddedEnumProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 2)
+	if err := outOfEmbeddedEnumProto2.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+}
+
 func TestNestedError3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	someProto3.SomeEmbeddedExists.SomeValue = 101 // should be less than 101
 	if err := someProto3.Validate(); err == nil {
 		t.Fatalf("expected fail due to nested SomeEmbeddedExists.SomeValue being wrong")
@@ -435,7 +462,7 @@ func TestNestedError3(t *testing.T) {
 }
 
 func TestCustomError_Proto3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	someProto3.CustomErrorInt = 30
 	expectedErr := "invalid field CustomErrorInt: My Custom Error"
 	if err := someProto3.Validate(); err == nil {
@@ -568,7 +595,7 @@ func TestUUID4Validation(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("proto2 uuid '%s'", tc.uuid), func(t *testing.T) {
-			msg := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid)
+			msg := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid, 0, 0)
 
 			err := msg.Validate()
 			failed := err != nil
@@ -578,7 +605,7 @@ func TestUUID4Validation(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("proto3 uuid '%s'", tc.uuid), func(t *testing.T) {
-			msg := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid)
+			msg := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid, 0, 0)
 
 			err := msg.Validate()
 			failed := err != nil

--- a/test/golang/validator_test.go
+++ b/test/golang/validator_test.go
@@ -23,8 +23,9 @@ const (
 func buildProto3(someString string, someInt uint32, identifier string, someValue int64, someDoubleStrict float64,
 	someFloatStrict float32, someDouble float64, someFloat float32, nonEmptyString string, repeatedCount uint32,
 	someStringLength string, someBytes []byte,
-	optionalUUIDAny, uuid4 string) *ValidatorMessage3 {
-	goodEmbeddedProto3 := &ValidatorMessage3_Embedded{
+	optionalUUIDAny, uuid4 string,
+	someEnum int32, someEmbeddedEnum int32) *ValidatorMessage3 {
+	goodEmbeddedProto3 := &ValidatorMessage3_EmbeddedMessage{
 		Identifier: identifier,
 		SomeValue:  someValue,
 	}
@@ -42,8 +43,8 @@ func buildProto3(someString string, someInt uint32, identifier string, someValue
 		SomeEmbedded:               nil,
 		SomeEmbeddedNonNullable:    goodEmbeddedProto3,
 		SomeEmbeddedExists:         goodEmbeddedProto3,
-		SomeEmbeddedRep:            []*ValidatorMessage3_Embedded{goodEmbeddedProto3},
-		SomeEmbeddedRepNonNullable: []*ValidatorMessage3_Embedded{goodEmbeddedProto3},
+		SomeEmbeddedRep:            []*ValidatorMessage3_EmbeddedMessage{goodEmbeddedProto3},
+		SomeEmbeddedRepNonNullable: []*ValidatorMessage3_EmbeddedMessage{goodEmbeddedProto3},
 
 		StrictSomeDouble:           someDoubleStrict,
 		StrictSomeDoubleRep:        []float64{someDoubleStrict, 0.5, 0.55, 0.6},
@@ -72,6 +73,9 @@ func buildProto3(someString string, someInt uint32, identifier string, someValue
 
 		UUIDAny:       optionalUUIDAny,
 		UUID4NotEmpty: uuid4,
+
+		SomeEnum:         EnumProto3(someEnum),
+		SomeEmbeddedEnum: ValidatorMessage3_EmbeddedEnum(someEmbeddedEnum),
 	}
 
 	goodProto3.Repeated = make([]int32, repeatedCount)
@@ -83,8 +87,9 @@ func buildProto2(someString string, someInt uint32, identifier string,
 	someValue int64, someDoubleStrict float64, someFloatStrict float32, someDouble float64,
 	someFloat float32, nonEmptyString string, repeatedCount uint32,
 	someStringLength string, someBytes []byte,
-	optionalUUIDAny, uuid5 string) *ValidatorMessage {
-	goodEmbeddedProto2 := &ValidatorMessage_Embedded{
+	optionalUUIDAny, uuid5 string,
+	someEnum int32, someEmbeddedEnum int32) *ValidatorMessage {
+	goodEmbeddedProto2 := &ValidatorMessage_EmbeddedMessage{
 		Identifier: &identifier,
 		SomeValue:  &someValue,
 	}
@@ -105,8 +110,8 @@ func buildProto2(someString string, someInt uint32, identifier string,
 
 		EmbeddedReq:            goodEmbeddedProto2,
 		EmbeddedNonNull:        goodEmbeddedProto2,
-		EmbeddedRep:            []*ValidatorMessage_Embedded{goodEmbeddedProto2},
-		EmbeddedRepNonNullable: []*ValidatorMessage_Embedded{goodEmbeddedProto2},
+		EmbeddedRep:            []*ValidatorMessage_EmbeddedMessage{goodEmbeddedProto2},
+		EmbeddedRepNonNullable: []*ValidatorMessage_EmbeddedMessage{goodEmbeddedProto2},
 
 		StrictSomeDoubleReq:        &someDoubleStrict,
 		StrictSomeDoubleReqNonNull: &someDoubleStrict,
@@ -137,6 +142,9 @@ func buildProto2(someString string, someInt uint32, identifier string,
 
 		UUIDAny:       &optionalUUIDAny,
 		UUID4NotEmpty: &uuid5,
+
+		SomeEnum:         (*EnumProto2)(&someEnum),
+		SomeEmbeddedEnum: (*ValidatorMessage_EmbeddedEnum)(&someEmbeddedEnum),
 	}
 
 	goodProto2.Repeated = make([]int32, repeatedCount)
@@ -146,7 +154,7 @@ func buildProto2(someString string, someInt uint32, identifier string,
 
 func TestGoodProto3(t *testing.T) {
 	var err error
-	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	goodProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 1, 1)
 	err = goodProto3.Validate()
 	if err != nil {
 		t.Fatalf("unexpected fail in validator: %v", err)
@@ -155,7 +163,7 @@ func TestGoodProto3(t *testing.T) {
 
 func TestGoodProto2(t *testing.T) {
 	var err error
-	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	goodProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 1, 1)
 
 	err = goodProto2.Validate()
 	if err != nil {
@@ -164,306 +172,254 @@ func TestGoodProto2(t *testing.T) {
 }
 
 func TestStringRegex(t *testing.T) {
-	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	tooLong1Proto3 := buildProto3("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooLong1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
-	if tooLong2Proto3.Validate() == nil {
-		t.Fatalf("expected fail in validator, but it didn't happen")
-	}
-	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	tooLong1Proto2 := buildProto2("toolong", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooLong1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	tooLong2Proto3 := buildProto3("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
+	if tooLong2Proto3.Validate() == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	tooLong2Proto2 := buildProto2("-%ab", 11, "bad#", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooLong2Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntLowerBounds(t *testing.T) {
-	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan10Proto3 := buildProto3("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan10Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan10Proto2 := buildProto2("-%ab", 9, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan10Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", -1, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestIntUpperBounds(t *testing.T) {
-	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan100Proto3 := buildProto3("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan100Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan100Proto2 := buildProto2("-%ab", 11, "abba", 101, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan100Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
 }
 
 func TestDoubleStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.3, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan035EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.300000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan035EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestDoubleStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.70000000001, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan065EpsilonProto3.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.6999999999, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan065EpsilonProto2.Validate() != nil {
 		t.Fatalf("unexpected fail in validator")
 	}
 }
 
 func TestFloatStrictLowerBounds(t *testing.T) {
-	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.2999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan035EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan035EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := greaterThan035EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan035EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.3000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := greaterThan035EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatStrictUpperBounds(t *testing.T) {
-	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	greaterThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.7000001, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if greaterThan065EpsilonProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan065EpsilonProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := lowerThan065EpsilonProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan065EpsilonProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.6999999, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := lowerThan065EpsilonProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.2499999, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.25, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestDoubleNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75111111, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.75, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictLowerBounds(t *testing.T) {
-	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	lowerThan0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.2499999, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if lowerThan0Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.25, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestFloatNonStrictUpperBounds(t *testing.T) {
-	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	higherThan1Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	higherThan1Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75111111, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if higherThan1Proto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	equalTo0Proto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.75, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := equalTo0Proto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestStringNonEmpty(t *testing.T) {
-	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	emptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if emptyStringProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	emptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if emptyStringProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	nonEmptyStringProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := nonEmptyStringProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	nonEmptyStringProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := nonEmptyStringProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestRepeatedEltsCount(t *testing.T) {
-	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4)
-
+	notEnoughEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if notEnoughEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4)
-
+	notEnoughEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 1, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if notEnoughEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4)
-
+	tooManyEltsProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooManyEltsProto3.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4)
-
+	tooManyEltsProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 14, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if tooManyEltsProto2.Validate() == nil {
 		t.Fatalf("expected fail in validator, but it didn't happen")
 	}
-	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	validEltsCountProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := validEltsCountProto3.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
-	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	validEltsCountProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := validEltsCountProto2.Validate(); err != nil {
 		t.Fatalf("unexpected fail in validator %v", err)
 	}
 }
 
 func TestMsgExist(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 
 	someProto3.SomeEmbedded = nil
 	if err := someProto3.Validate(); err != nil {
@@ -478,35 +434,48 @@ func TestMsgExist(t *testing.T) {
 }
 
 func TestStringLengthValidator(t *testing.T) {
-	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "abc456", stableBytes, uuid1, uuid4)
-
+	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "abc456", stableBytes, uuid1, uuid4, 0, 0)
 	if err := StringLengthErrorProto3.Validate(); err == nil {
 		t.Fatalf("validate shouldn't fail on error length")
 	}
-
-	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := StringLengthSuccess.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on equal length")
 	}
 }
 
 func TestBytesLengthValidator(t *testing.T) {
-	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "abc456", []byte("anc"), uuid1, uuid4)
-
+	StringLengthErrorProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "abc456", []byte("anc"), uuid1, uuid4, 0, 0)
 	if err := StringLengthErrorProto3.Validate(); err == nil {
 		t.Fatalf("validate shouldn't fail on error length")
 	}
-
-	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
-
+	StringLengthSuccess := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 	if err := StringLengthSuccess.Validate(); err != nil {
 		t.Fatalf("validate shouldn't fail on equal length")
 	}
 }
 
+func TestValueIsInEnum(t *testing.T) {
+	outOfTopLevelEnumProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 2, 0)
+	if err := outOfTopLevelEnumProto3.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	outOfTopLevelEnumProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 2, 0)
+	if err := outOfTopLevelEnumProto2.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	outOfEmbeddedEnumProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 2)
+	if err := outOfEmbeddedEnumProto3.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+	outOfEmbeddedEnumProto2 := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 2)
+	if err := outOfEmbeddedEnumProto2.Validate(); err == nil {
+		t.Fatalf("expected fail in validator, but it didn't happen")
+	}
+}
+
 func TestNestedError3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 
 	someProto3.SomeEmbeddedExists.SomeValue = 101 // should be less than 101
 	if err := someProto3.Validate(); err == nil {
@@ -517,7 +486,7 @@ func TestNestedError3(t *testing.T) {
 }
 
 func TestCustomError_Proto3(t *testing.T) {
-	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4)
+	someProto3 := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, uuid4, 0, 0)
 
 	someProto3.CustomErrorInt = 30
 	expectedErr := "invalid field CustomErrorInt: My Custom Error"
@@ -627,22 +596,18 @@ func TestUUID4Validation(t *testing.T) {
 			uuid: uuid1,
 			fail: true,
 		},
-
 		{
 			uuid: uuid4,
 			fail: false,
 		},
-
 		{
 			uuid: "",
 			fail: true,
 		},
-
 		{
 			uuid: "66bb25e2-2e0d",
 			fail: true,
 		},
-
 		{
 			uuid: "1234abcd",
 			fail: true,
@@ -651,7 +616,7 @@ func TestUUID4Validation(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("proto2 uuid '%s'", tc.uuid), func(t *testing.T) {
-			msg := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid)
+			msg := buildProto2("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid, 0, 0)
 
 			err := msg.Validate()
 			failed := err != nil
@@ -661,7 +626,7 @@ func TestUUID4Validation(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("proto3 uuid '%s'", tc.uuid), func(t *testing.T) {
-			msg := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid)
+			msg := buildProto3("-%ab", 11, "abba", 99, 0.5, 0.5, 0.5, 0.5, "x", 4, "1234567890", stableBytes, uuid1, tc.uuid, 0, 0)
 
 			err := msg.Validate()
 			failed := err != nil
@@ -669,6 +634,5 @@ func TestUUID4Validation(t *testing.T) {
 				t.Errorf("Expected validation failure: %t, but got %t, err: %v", tc.fail, failed, err)
 			}
 		})
-
 	}
 }

--- a/test/validator_proto2.proto
+++ b/test/validator_proto2.proto
@@ -7,11 +7,23 @@ package validatortest;
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "github.com/mwitkow/go-proto-validators/validator.proto";
 
+// Top-level enum type definition.
+enum EnumProto2 {
+	alpha2 = 0;
+	beta2 = 1;
+}
+
 message ValidatorMessage {
 	// Embedded message test structure.
-	message Embedded {
+	message EmbeddedMessage {
 		optional string Identifier = 1 [(validator.field) = {regex: "^[a-z]{2,5}$"}];
 		required int64 SomeValue = 2 [(validator.field) = {int_gt: 0, int_lt: 100}];
+	}
+
+	// Embedded enum type definition.
+	enum EmbeddedEnum {
+		zero = 0;
+		one = 1;
 	}
 
 	// String regex constraint tests.
@@ -28,10 +40,10 @@ message ValidatorMessage {
 	repeated uint32 IntRepNonNull = 9 [(validator.field) = {int_gt: 0}];
 
 	// Embedded message recursive constraint tests.
-	required Embedded embeddedReq = 10;
-	required Embedded embeddedNonNull = 11 [(gogoproto.nullable) = false];
-	repeated Embedded embeddedRep = 12;
-	repeated Embedded embeddedRepNonNullable = 13 [(gogoproto.nullable) = false];
+	required EmbeddedMessage embeddedReq = 10;
+	required EmbeddedMessage embeddedNonNull = 11 [(gogoproto.nullable) = false];
+	repeated EmbeddedMessage embeddedRep = 12;
+	repeated EmbeddedMessage embeddedRepNonNullable = 13 [(gogoproto.nullable) = false];
 
 	// Custom error tests.
 	optional int32 CustomErrorInt = 16 [(validator.field) = {int_gt: 10, human_error: "My Custom Error"}];
@@ -77,4 +89,8 @@ message ValidatorMessage {
 
 	optional string UUIDAny = 42 [(validator.field) = {uuid_ver: 0}];
 	required string UUID4NotEmpty = 43 [(validator.field) = {uuid_ver: 4, string_not_empty: true}];
+
+	// Enum tests.
+	required EnumProto2 someEnum = 44 [(validator.field) = {is_in_enum: true}];
+	required EmbeddedEnum someEmbeddedEnum = 45 [(validator.field) = {is_in_enum: true}];
 }

--- a/test/validator_proto3.proto
+++ b/test/validator_proto3.proto
@@ -7,11 +7,23 @@ package validatortest;
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "github.com/mwitkow/go-proto-validators/validator.proto";
 
+// Top-level enum type definition.
+enum EnumProto3 {
+	alpha3 = 0;
+	beta3 = 1;
+}
+
 message ValidatorMessage3 {
 	// Embedded message test structure.
-	message Embedded {
+	message EmbeddedMessage {
 		string Identifier = 1 [(validator.field) = {regex: "^[a-z]{2,5}$"}];
 		int64 SomeValue = 2 [(validator.field) = {int_gt: 0, int_lt: 100}];
+	}
+
+	// Embedded enum type definition.
+	enum EmbeddedEnum {
+		zero = 0;
+		one = 1;
 	}
 
 	// String regex constraint tests.
@@ -26,11 +38,11 @@ message ValidatorMessage3 {
 	repeated uint32 SomeIntRepNonNull = 8 [(validator.field) = {int_gt: 10}];
 
 	// Embedded message existence and recursive constraint tests.
-	Embedded someEmbedded = 10;
-	Embedded someEmbeddedNonNullable = 11 [(gogoproto.nullable) = false];
-	Embedded someEmbeddedExists = 12 [(validator.field) = {msg_exists : true}];
-	repeated Embedded someEmbeddedRep = 14;
-	repeated Embedded someEmbeddedRepNonNullable = 15 [(gogoproto.nullable) = false];
+	EmbeddedMessage someEmbedded = 10;
+	EmbeddedMessage someEmbeddedNonNullable = 11 [(gogoproto.nullable) = false];
+	EmbeddedMessage someEmbeddedExists = 12 [(validator.field) = {msg_exists : true}];
+	repeated EmbeddedMessage someEmbeddedRep = 14;
+	repeated EmbeddedMessage someEmbeddedRepNonNullable = 15 [(gogoproto.nullable) = false];
 
 	// Custom error tests.
 	int32 CustomErrorInt = 16 [(validator.field) = {int_lt: 10, human_error: "My Custom Error"}];
@@ -72,4 +84,8 @@ message ValidatorMessage3 {
 
 	string UUIDAny = 42 [(validator.field) = {uuid_ver: 0}];
 	string UUID4NotEmpty = 43 [(validator.field) = {uuid_ver: 4, string_not_empty: true}];
+
+	// Enum tests.
+	EnumProto3 someEnum = 44 [(validator.field) = {is_in_enum: true}];
+	EmbeddedEnum someEmbeddedEnum = 45 [(validator.field) = {is_in_enum: true}];
 }


### PR DESCRIPTION
This enhances the is_in_enum validation option for enums which is defined nested, such as defined in a message, which checks if incoming values are actually defined in the enum. 
# source proto:
```proto
syntax = "proto3";

package namor.api.stream;
import "github.com/mwitkow/go-proto-validators/validator.proto";

option go_package = ";stream";

message Task {
    enum Type {
        live = 0;
        record = 1;
    }
    Type type = 1 [(validator.field) = {is_in_enum : true}];
}
```

# Before 
## install command
```bash
go get github.com/mwitkow/go-proto-validators/protoc-gen-govalidators
```
### code generated
```go
// Code generated by protoc-gen-gogo. DO NOT EDIT.
// source: task.proto

package stream

import (
	fmt "fmt"
	math "math"
	proto "github.com/golang/protobuf/proto"
	_ "github.com/mwitkow/go-proto-validators"
	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
)

// Reference imports to suppress errors if they are not otherwise used.
var _ = proto.Marshal
var _ = fmt.Errorf
var _ = math.Inf

func (this *Task) Validate() error {
	if _, ok := Type_name[int32(this.Type)]; !ok {
		return github_com_mwitkow_go_proto_validators.FieldError("Type", fmt.Errorf(`value '%v' must be a valid Type field`, this.Type))
	}
	return nil
}
```
### compiler complains
```
task.validator.pb.go:20:14: undefined: Type_name
```
# After
## install command
```bash
go get github.com/searKing/go-proto-validators/protoc-gen-govalidators
```
### code generated
```go
// Code generated by protoc-gen-gogo. DO NOT EDIT.
// source: task.proto

package stream

import (
	fmt "fmt"
	math "math"
	proto "github.com/golang/protobuf/proto"
	_ "github.com/mwitkow/go-proto-validators"
	github_com_mwitkow_go_proto_validators "github.com/mwitkow/go-proto-validators"
)

// Reference imports to suppress errors if they are not otherwise used.
var _ = proto.Marshal
var _ = fmt.Errorf
var _ = math.Inf

func (this *Task) Validate() error {
	if _, ok := Task_Type_name[int32(this.Type)]; !ok {
		return github_com_mwitkow_go_proto_validators.FieldError("Type", fmt.Errorf(`value '%v' must be a valid Task_Type field`, this.Type))
	}
	return nil
}
```
### compiler complains
everything is OK