### PR TITLE
Add full import path to go_package option

### DIFF
--- a/validator.proto
+++ b/validator.proto
@@ -11,7 +11,7 @@ package validator;
 
 import "google/protobuf/descriptor.proto";
 
-option go_package = "validator";
+option go_package = "github.com/mwitkow/go-proto-validators;validator";
 
 // TODO(mwitkow): Email protobuf-global-extension-registry@google.com to get an extension ID.
 


### PR DESCRIPTION
When currently using protoc I get the following warning:

```
2020/04/14 17:07:18 WARNING: Deprecated use of 'go_package' option without a full import path in "github.com/mwitkow/go-proto-validators/validator.proto", please specify:
	option go_package = "github.com/mwitkow/go-proto-validators;validator";
A future release of protoc-gen-go will require the import path be specified.
See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.
```

This small change fixes this warning for me.

As far as I know this is not a breaking change. The web page mentioned by this warning the following states: `The Go package name of generated code will be the last path component of the go_package option.`.