### PR TITLE
Correct supported Go versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ deeply-nested messages.
 
 Using Protobuf validators is currently verified to work with:
 
-- Go 1.11, 1.12, 1.13
+- Go 1.11 or later
 - [Protobuf](https://github.com/protocolbuffers/protobuf) @ `v3.8.0`
 - [Go Protobuf](https://github.com/golang/protobuf) @ `v1.3.2`
 - [Gogo Protobuf](https://github.com/gogo/protobuf) @ `v1.3.0`


### PR DESCRIPTION
I fixed ✨ 

Or should I fix README like this?

> Go 1.11, 1.12, 1.13, 1.14, 1.15

https://github.com/mwitkow/go-proto-validators/issues/80

