### PR TITLE
Enable proto-specified readable errors for msg_exists validation.

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -357,7 +357,7 @@ func (p *plugin) generateProto3Message(file *generator.FileDescriptor, message *
 				if nullable && !repeated {
 					p.P(`if nil == `, variableName, `{`)
 					p.In()
-					p.P(`return `, p.validatorPkg.Use(), `.FieldError("`, fieldName, `",`, p.fmtPkg.Use(), `.Errorf("message must exist"))`)
+					p.generateErrorString(variableName, fieldName, `exist`, fieldValidator)
 					p.Out()
 					p.P(`}`)
 				} else if repeated {


### PR DESCRIPTION
My only concern here is that the specified human readable errors may conflict with other validations being performed on the field
(this could be the reason that upstream didn't implement this). May not be a common case in practice.