### PR TITLE
Do not force dependants to depend on bazel_gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,12 +1,7 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-
-gazelle(
-    name = "gazelle",
-)
 
 # gazelle:prefix github.com/mwitkow/go-proto-validators
 # gazelle:build_file_name BUILD.bazel

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ prepare_deps:
 
 gazelle:
 	@bash bazel run --run_under="cd ${mkfile_dir} && " @bazel_gazelle//cmd/gazelle -- update-repos -from_file=go.mod -to_macro=go_deps.bzl%go_repositories
-	@bash bazel run //:gazelle -- --mode=fix --exclude=deps --exclude=examples --exclude=test
+	@bash bazel run //gazelle -- --mode=fix --exclude=deps --exclude=examples --exclude=test
 
 install:
 	@echo "--- Installing 'govalidators' binary to GOBIN."

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -1,0 +1,5 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+gazelle(
+    name = "gazelle",
+)


### PR DESCRIPTION
By loading the "gazelle" rule from @bazel_gazelle in the top-level build
file, all users of targets in that file have to depend on bazel_gazelle.
This is particular problematic for rules_go, which depends on
//:validators_golang but should not depend on bazel_gazelle.

This is resolved by moving the gazelle rule definition into a separate
Bazel package.