### PR TITLE
fix: validatorWithNonRepeatedConstraint cannot detect repeated constraint

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -51,7 +51,6 @@ package plugin
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -664,22 +663,8 @@ func (p *plugin) validatorWithNonRepeatedConstraint(fv *validator.FieldValidator
 		return false
 	}
 
-	// Need to use reflection in order to be future-proof for new types of constraints.
-	v := reflect.ValueOf(*fv)
-	for i := 0; i < v.NumField(); i++ {
-		fieldName := v.Type().Field(i).Name
-
-		// All known validators will have a pointer type and we should skip any fields
-		// that are not pointers (i.e unknown fields, etc) as well as 'nil' pointers that
-		// don't lead to anything.
-		if v.Type().Field(i).Type.Kind() != reflect.Ptr || v.Field(i).IsNil() {
-			continue
-		}
-
-		// Identify non-repeated constraints based on their name.
-		if fieldName != "RepeatedCountMin" && fieldName != "RepeatedCountMax" {
-			return true
-		}
+	if fv.RepeatedCountMin == nil && fv.RepeatedCountMax == nil {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
#### the problem part of .proto file
```proto
message ArtworkUidsRequest{
  repeated string ArtworkUids =1 [(validator.field)={repeated_count_min:1,human_error:"13021"}]; 
}
```
then, generated codes like this. `item` is not uesd.
```go
func (this *ArtworkUidsRequest) Validate() error {
	if len(this.ArtworkUids) < 1 {
		return github_com_mwitkow_go_proto_validators.FieldError("ArtworkUids", fmt.Errorf(`13021`))
	}
	for _, item := range this.ArtworkUids {
	}
	return nil
}
```
when i check the code, i found the function `validatorWithNonRepeatedConstraint` cannot detect the two fields "RepeatedCountMin" and "RepeatedCountMax"